### PR TITLE
Develop

### DIFF
--- a/src/database/migrations/2026_03_15_043256_create_repositories_table.php
+++ b/src/database/migrations/2026_03_15_043256_create_repositories_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('repositories', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->string('external_repository_id')->nullable();
+            $table->string('repository_ref');
+            $table->string('default_branch')->nullable();
+            $table->string('source_system');
+            $table->string('webhook_token_hash');
+            $table->boolean('is_active')->default(true);
+            $table->string('last_scan_status')->nullable();
+            $table->timestamp('last_scanned_at')->nullable();
+            $table->unsignedInteger('last_vulnerability_count')->default(0);
+            $table->unsignedInteger('critical_count')->default(0);
+            $table->unsignedInteger('high_count')->default(0);
+            $table->unsignedInteger('medium_count')->default(0);
+            $table->unsignedInteger('low_count')->default(0);
+            $table->json('scanner_metadata')->nullable();
+            $table->timestamps();
+
+            $table->unique(['team_id', 'slug']);
+            $table->unique(['team_id', 'repository_ref']);
+            $table->index(['team_id', 'is_active']);
+            $table->index(['source_system', 'external_repository_id']);
+            $table->index('last_scan_status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('repositories');
+    }
+};


### PR DESCRIPTION
## Description
Adds the initial `repositories` table migration for tracked repository metadata, team ownership, webhook token hash storage, and latest scan summary fields.

## Linked Issue
Closes #5

## Changes
- add the `repositories` migration with team ownership, repository identity fields, source metadata, active flag, and timestamps
- store webhook credentials in a `webhook_token_hash` column and add latest scan summary fields plus severity counters
- add portable v1 uniqueness and indexing for team-scoped repository lookups and scan status queries

## Testing
- [x] `composer test`
- [ ] `npm run build` (if frontend assets changed)
- [ ] Static analysis command (if configured)
- [x] Additional targeted checks:
  - `docker compose run --rm php ./vendor/bin/pint --dirty --format agent`
  - `docker compose run --rm composer test`
  - Static analysis is not configured as a first-class repo command in this repository.

## Checklist
- [x] Code follows project style
- [ ] Tests added or updated when behavior changed
- [x] PR links the issue
- [x] No console errors
