### PR TITLE
Add repository vulnerabilities migration

### DIFF
--- a/src/database/migrations/2026_03_15_043559_create_repository_vulnerabilities_table.php
+++ b/src/database/migrations/2026_03_15_043559_create_repository_vulnerabilities_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('repository_vulnerabilities', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('repository_id')->constrained()->cascadeOnDelete();
+            $table->string('advisory_id');
+            $table->string('package_name');
+            $table->string('package_purl')->nullable();
+            $table->string('affected_version')->nullable();
+            $table->string('fixed_version')->nullable();
+            $table->string('severity')->nullable();
+            $table->decimal('severity_score', 5, 2)->nullable();
+            $table->string('manifest_path')->nullable();
+            $table->string('ecosystem');
+            $table->string('summary')->nullable();
+            $table->text('details')->nullable();
+            $table->json('references_json')->nullable();
+            $table->json('aliases_json')->nullable();
+            $table->json('affected_ranges_json')->nullable();
+            $table->timestamp('detected_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['repository_id', 'ecosystem']);
+            $table->index(['repository_id', 'severity']);
+            $table->index(['repository_id', 'manifest_path']);
+            $table->index('advisory_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('repository_vulnerabilities');
+    }
+};


### PR DESCRIPTION
## Description
Adds the initial `repository_vulnerabilities` table migration for current repository findings, including advisory, package, severity, JSON payload, and detection timestamp fields.

## Linked Issue
Closes #6

## Changes
- add the `repository_vulnerabilities` migration with the repository foreign key and documented advisory, package, severity, and timestamp columns
- add JSON payload columns for references, aliases, and affected ranges without extra normalization
- add the required indexes for repository ecosystem, severity, manifest path, and advisory lookups

## Testing
- [x] `composer test`
- [ ] `npm run build` (if frontend assets changed)
- [ ] Static analysis command (if configured)
- [x] Additional targeted checks:
  - `docker compose run --rm php ./vendor/bin/pint --dirty --format agent`
  - `docker compose run --rm composer test`
  - Static analysis is not configured as a first-class repo command in this repository.

## Checklist
- [x] Code follows project style
- [ ] Tests added or updated when behavior changed
- [x] PR links the issue
- [x] No console errors
